### PR TITLE
Proposed changes to the governance document from the working committee

### DIFF
--- a/Definition_of_Done_for_Feature_Branches.md
+++ b/Definition_of_Done_for_Feature_Branches.md
@@ -1,10 +1,10 @@
 # Definition of Done for Feature Branches
-The definition of done is an agile document that clarifies what it means for a set of development work to be completed.  It is both a check list and a set of guidelines that should be followed.
+The definition of done is an agile document that clarifies what it means for a set of development tasks to be completed.  It is both a check list and a set of guidelines that should be followed.
 
 ## Development Practices
 - Code has followed the style guide for BOINC (http://boinc.berkeley.edu/trac/wiki/CodingStyle)
-- Does not contain unrelated code changes
-- Uses atomic commits (https://www.freshconsulting.com/atomic-commits/)
+- Commit does not contain unrelated code changes
+- Code uses atomic commits (https://www.freshconsulting.com/atomic-commits/)
 
 ## Testing
 - The code compiles on relevant major platforms (this should be available via automation)

--- a/Development_Workflow.md
+++ b/Development_Workflow.md
@@ -1,5 +1,5 @@
 # Development Workflow
-The purpose of a development workflow is to make sure that the BOINC platform produces high quality code that solves the problems of its users. As such, the development workflow needs to have checkpoints to allow for the review and discussion of the following questions:
+The purpose of a development workflow is to make sure that the BOINC is a high-quality platform that solves the problems of its users. As such, the development workflow needs to have checkpoints to allow for the review and discussion of the following questions:
 
 - Should this item be implemented?
 - How should this item be implemented?

--- a/Governance.md
+++ b/Governance.md
@@ -128,6 +128,7 @@ The functions of the PMC are:
 Individual PMC members are expected to actively participate in these processes by:
 - Reading the PMC public and private email lists (See [section 3. Communication channels](#3-communication-channels) below)
 - Participating in votes (see [section 5.3 PMC decisions](#53-pmc-decisions) below)
+- Regularly participate in monthly PMC calls
 
 Members of the PMC can resign by sending an email to the PMC chair or the PMC private email list.
 
@@ -160,15 +161,15 @@ The "PMC Secretary" is a member of the PMC, appointed and ratified by the PMC to
     - Who voted
   - In the event that the PMC determines a vote is sensitive in nature, then they can decide to not announce the vote publicly.  The PMC is encouraged to do this rarely and with clear justification.
 
-The PMC Secretary is appointed by the Chair and ratified by the PMC to serve in this role.  Another person can be appointed to this position as determined by the PMC Chair.
+The PMC Secretary is appointed by the Chair and ratified by the PMC using consensus voting to serve in this role.  Another person can be appointed to this position as determined by the PMC Chair.
 
-#### 2.5.2 PMC Elections
+#### 2.5.2 PMC Chair Elections
 Any member of the PMC can call for an election of the PMC Chair.  When a member of the PMC calls for an election they must specify that the election is either to immediately replace the current Chair or if the newly elected Chair will start their term when the current term expires. 
 
 Elections shall use the election decision process outlined in [section 5.3.2 Election decisions](#532-election-decisions) below.
 
 #### 2.5.3 Inactive Removal
-PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without participating in at least one PMC meeting should be considered for removal from the PMC. 
+PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without participating in at least one PMC meeting should be considered for removal from the PMC.  Removal requires a successful vote using the process outlined in [special voting procedures](#531decisions-where-special-voting-procedures-are-mandatory) below.
 
 ### 2.6 Official Record
 The official list of committers, supporters and members of the PMC shall be maintained by the secretary at http://boinc.berkeley.edu/trac/wiki/ProjectGovernance. This page shall also clearly list the email address of the PMC public email list with instructions on how someone can subscribe to the list.
@@ -212,20 +213,7 @@ If you are reporting a bug or requesting a feature, make sure you review the [De
 
 ## 5. Decision processes
 ### 5.1 Voting Processes
-Because one of the fundamental aspects of accomplishing things within the BOINC framework is doing so by consensus, it is necessary to determine whether consensus has been reached. This is done by voting.
-
-There are a few types of items that require a vote:
-- Whether or not to fix a bug or implement a feature request (documented and voted on as an issue on github)
-- The design of a proposed feature or bug fix (documented and voted on within the relevant issue on github)
-- A change in code or configuration to the system (documented and voted on as a pull request on github)
-- General availability of stable releases (documented and voted on in the boinc_alpha mailing list)
-- Procedural and other issues
-  - Other committer votes not otherwise identified will be voted on in the boinc_dev mailing list
-  - Other PMC votes not otherwise identified will be voted on in the boinc_adm or private boinc_pmc mailing lists as deemed appropriate by the PMC.
-
-Votes on design reviews, pull requests, and general availability of a stable release shall use the consensus voting process.
-
-Procedural and other issues shall always follow the majority voting process.
+Decisions in the BOINC community should made easily but also in a way that promotes a collaborative environment.  As a result, the following mechanisms for voting on a decision are defined:
 
 #### 5.1.1 Consensus Voting
 Consensus voting consists of a 7 day review period. During this time anyone can review and discuss the item. At the end of the 7 day period, if there is at least one "Yes" vote for an item (apart from the vote of the person who created the item) and zero "No" votes, then the vote shall be deemed as having passed.
@@ -237,30 +225,48 @@ If discussion cannot remove the concerns that resulted in the "No" vote, then th
 If the vote fails, but the original proposer of the item still believes that the item is worth pursuing, they can appeal to the PMC. The PMC shall consider the appeal at their next regularly scheduled meeting and will use Majority Voting to determine the outcome.
 
 #### 5.1.2 Majority Voting
-Majority voting requires that at least 2/3rds of eligible voters cast a vote and, of those who cast a vote, a majority must approve the item.
+Majority voting requires that at least 66% of eligible voters cast a vote and, of those who cast a vote, a majority must approve the item.
+
+#### 5.1.3. Super-Majority Voting
+Super-majority voting requires that at least 75% of eligible voters cast a vote and, of those who cast a vote, a majority must approve the item.
 
 ### 5.2 Committer decisions
 Committers can vote on issues surrounding the technical infrastructure of the project and the code base itself. This includes voting to determine if a reported bug, feature request, proposed design, or pull request should be accepted. Committers are encouraged to review and participate in the discussion of any of these items, but they are also expected to know when it is advisable to get help from other committers who are stronger in the technology involved or have more experience in the area of application under consideration. Committers are expected to understand the Development Workflow and Client Release Process and their associated guidelines before voting to approve.
 
 Committers are expected to subscribe to notifications from github in order to be aware of proposals under consideration. Committers should make a reasonable attempt to respond quickly if they are personally asked to review an item. Since most decisions that committers are involved in will use consensus voting, it is important for them to try to remain aware of proposed items.
 
-### 5.3 PMC decisions
-Certain specific types of decisions by the PMC must be made by a special voting procedure (see below).
+Different committer decisions should be recorded and discussed in the following locations:
+- Whether or not to fix a bug or implement a feature request (documented and voted on as an issue on github)
+- The design of a proposed feature or bug fix (documented and voted on within the relevant issue on github)
+- A change in code or configuration to the system (documented and voted on as a pull request on github)
+- General availability of stable releases (documented and voted on in the boinc_alpha mailing list)
+- All other committer decisions should be discussed and voted on in the boinc_dev mailing list.
 
-#### 5.3.1 Decisions where special voting procedures are mandatory
-Decisions of the following types must be made by a special vote of the PMC:
-- Intellectual property issues, e.g. those involving copyright and licensing of BOINC code
-- Other legal and financial decisions
-- PMC membership changes
-- Changes to the project governance structure (i.e. changes to this document)
+
+- Procedural and other issues
+  - Other committer votes not otherwise identified will be voted on in the boinc_dev mailing list
+  - Other PMC votes not otherwise identified will be voted on in the boinc_adm or private boinc_pmc mailing lists as deemed appropriate by the PMC.
+
+Votes on design reviews, pull requests, and general availability of a stable release shall use the consensus voting process.
+
+Procedural and other issues shall always follow the majority voting process.
+
+
+### 5.3 PMC decisions
+PMC decisions will be made by majority voting unless specified in section 5.3.1 or in section 5.3.2.
 
 Votes can be called by any PMC member. The special voting process is:
 - A vote is announced on either the PMC public or private email list (depending on the sensitivity of topic), phrasing the issue as a yes/no decision.
 - If the vote is announced on the PMC public list, then the entire community is encouraged to participate in the discussion of the vote and that discussion should occur on the PMC public list. 
 - If the vote is accouned on the PMC private list, then discussion is limited to PMC members and it shall be conducted in a meeting or on the PMC private email list.
 - Vote outcomes are announced by the PMC secretary as described in [section 2.5.1.2 PMC Secretary](#2512-pmc-secretary)
-- Votes on these issues requires that at least 75% of eligible voters cast a vote and, of those who cast a vote, a majority must approve the item.
-- If there is not agreement of a majority of at least 75% of eligible voters, no action is taken on the issue.
+
+#### 5.3.1 PMC Decisions that Require Super-Majority Voting 
+The following types of decisions require a super-majority vote of the PMC
+- Intellectual property issues, e.g. those involving copyright and licensing of BOINC code
+- Other legal and financial decisions
+- PMC membership changes
+- Changes to the project governance structure (i.e. changes to this document)
 
 #### 5.3.2 Election decisions
 The PMC will conduct elections to elect the PMC Chair.   An election starts when any member of the PMC calls for an election as specified in section 2.5.2 PMC Elections.  This call starts a 7 day nomination period which is followed by a 7 day voting period.  Any member of the PMC can nominate themselves or another member of the PMC to be the PMC Chair.  A nomination is only valid if the person nominated accepts the nomination.  Once the 7 day nomination period ends, the 7 day voting period begins automatically.  At the conclusion of 7 day voting period and if at least 75% of the membership of the PMC has voted, then the person with the majority of votes is elected. 

--- a/Governance.md
+++ b/Governance.md
@@ -125,6 +125,8 @@ Individual PMC members are expected to actively participate in these processes b
 - Reading the PMC public and private email lists (See [section 3. Communication channels](#3-communication-channels) below)
 - Participating in votes (see [section 5.3 PMC decisions](#53-pmc-decisions) below)
 
+Members of the PMC can resign by sending an email to the PMC chair or the PMC private email list.
+
 #### 2.5.1 PMC Positions
 ##### 2.5.1.1 PMC Chair
 The “PMC Chair” is a member of the PMC, elected by the PMC to take this role. The chair has the following responsibilities:

--- a/Governance.md
+++ b/Governance.md
@@ -73,6 +73,8 @@ Committers are expected to do several of the following:
 - Review pull requests and merge code when appropriate
 - Identify contributors who would be helpful as committers; nominate these contributors to the PMC
 
+Commiters can resign by sending an email to the PMC chair or the PMC public email list.
+
 ### 2.4 Supporters
 "Supporters" are contributors who have shown, via continued contribution over a period of time, their value to the project.  Supporters are focused on the end user experience and support the project by engaging with end-users wherever they may engage with the BOINC software and BOINC projects to both help the end-users as well as open issues as needed when there is a need for a change in the software.  Supporters also contribute by performing functions such as testing, enhancing documentation, and creating translations.
 
@@ -100,6 +102,8 @@ Supporters are expected to do one or more of the following:
 - Read the communication channels relevant to their area(s)
 - Assist with testing new releases of the software
 - Identify contributors who would be helpful as supporters; nominate these contributors to the PMC
+
+Supporters can resign by sending an email to the PMC chair or the PMC public email list.
 
 ### 2.5 Project Management Committee
 The Project Management Committee (PMC) is a group of community members who engage with and play a leadership role on the BOINC project.  They are selected on the basis of one or more of the following criteria:

--- a/Governance.md
+++ b/Governance.md
@@ -262,7 +262,7 @@ PMC decisions will be made by majority voting unless specified in section 5.3.1 
 Votes can be called by any PMC member. The process is:
 - A vote is announced on either the PMC public or private email list (depending on the sensitivity of topic), phrasing the issue as a yes/no decision.
 - If the vote is announced on the PMC public list, then the entire community is encouraged to participate in the discussion of the vote and that discussion should occur on the PMC public list. 
-- If the vote is accouned on the PMC private list, then discussion is limited to PMC members and it shall be conducted in a meeting or on the PMC private email list.
+- If the vote is announced on the PMC private list, then discussion is limited to PMC members and it shall be conducted in a meeting or on the PMC private email list.
 - Vote outcomes are announced by the PMC secretary as described in [section 2.5.1.2 PMC Secretary](#2512-pmc-secretary)
 
 #### 5.3.1 PMC Decisions that Require Super-Majority Voting 

--- a/Governance.md
+++ b/Governance.md
@@ -46,7 +46,7 @@ Anyone can be a user. The project asks its users to participate in the project a
 In some forms of contribution, such as programming and documentation, contributors submit changes by developing code in branches and submitting them as pull requests for review by committers (see the next section). As contributors gain experience, their reputation within the community will increase. Contributors can nominate themselves or other people to the PMC as potential committers. 
 
 ### 2.3 Committers
-“Committers” are contributors who have shown, via a sequence of positive contributions, their value to the project. Committers facilitate the software development process both by contributing code themselves and also by mentoring contributors to help them become more effective contributors. Only committers can merge a pull request into the master branch and they should only do so through the process defined in [4 Contribution Process](#4-contribution-processes). Committers have voting rights in the consensus process as it pertains to proposed design changes and to the reviews of pull requests. They contribute to discussion and approval of the software development process as documented in [4 Contribution Process](#4-contribution-processes).
+“Committers” are contributors who have shown, via a sequence of positive contributions, their value to the project. Committers facilitate the software development process both by contributing code themselves and also by mentoring contributors to help them become more effective contributors. Only committers can merge a pull request into the master branch and they should only do so through the process defined in [section 4. Contribution Process](#4-contribution-processes). Committers have voting rights in the consensus process as it pertains to proposed design changes and to the reviews of pull requests. They contribute to discussion and approval of the software development process as documented in [section 4. Contribution Process](#4-contribution-processes).
 
 Each committer will work on one or more “areas” of the BOINC project:
 - Software development and maintenance
@@ -103,7 +103,7 @@ Supporters are expected to do one or more of the following:
 
 ### 2.5 Project Management Committee
 The Project Management Committee (PMC) is a group of community members who engage with and play a leadership role on the BOINC project.  They are selected on the basis of one or more of the following criteria:
-- Directly contributing in any of the ways listed in [Section 2.2 Contributors](#22-contributors)
+- Directly contributing in any of the ways listed in [section 2.2 Contributors](#22-contributors)
 - Operating a related system, such as an account manager, that is used by a significant number of volunteers
 - Operating a project with a significant number of volunteers
 - Contributing significant resources to the BOINC project, for example by paying the salary of a contributor
@@ -122,8 +122,8 @@ The functions of the PMC are:
 - And any other such other thing as might be required from time to time     
 
 Individual PMC members are expected to actively participate in these processes by:
-- Reading the PMC public and private email lists (See [3 Communication channels](#3-communication-channels) below)
-- Participating in votes (See [5.3 PMC decisions](#53-pmc-decisions) below)
+- Reading the PMC public and private email lists (See [section 3. Communication channels](#3-communication-channels) below)
+- Participating in votes (see [section 5.3 PMC decisions](#53-pmc-decisions) below)
 
 #### 2.5.1 PMC Positions
 ##### 2.5.1.1 PMC Chair
@@ -142,7 +142,7 @@ The "PMC Secretary" is a member of the PMC, elected by the PMC to take this role
   - Must officially record who attends each meeting as part of the minutes
 - Ensure that a public version of the notes is distributed on the public PMC mailing list
 - Determine if PMC members need to be removed due to inactivity
-- Maintain the official record of committers, supporters and members of the PMC (See [2.6 Official Record](#26-official-record) below)
+- Maintain the official record of committers, supporters and members of the PMC (see [section 2.6 Official Record](#26-official-record) below)
 - Act as the official vote counter and recorder for all votes taken
   - An email to the private PMC list must made at the conclusion of each vote stating:
     - What was the issue voted on
@@ -159,7 +159,7 @@ The PMC Secretary shall be elected for a term of one year.   They can be re-elec
 #### 2.5.2 PMC Elections
 Any member of the PMC can call for an election of the PMC Chair or Secretary.  When a member of the PMC calls for an election they must specify that the election is either to immediately replace the current Chair or Secretary or if the newly elected Chair or Secretary will start their term when the current term expires. 
 
-Elections shall use the election decision process outlined in [5.3.2 Election decisions](#532-election-decisions) below.
+Elections shall use the election decision process outlined in [section 5.3.2 Election decisions](#532-election-decisions) below.
 
 #### 2.5.3 Inactive Removal
 PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without participating in at least one PMC meeting will be subject to removal from the PMC. 

--- a/Governance.md
+++ b/Governance.md
@@ -250,14 +250,11 @@ Different committer decisions should be recorded and discussed in the following 
 - General availability of stable releases (documented and voted on in the boinc_alpha mailing list)
 - All other committer decisions should be discussed and voted on in the boinc_dev mailing list.
 
+Votes on reported bugs, feature requests, proposed designs, and pull requests shall use the [optimistic consensus voting](#5111-optimistic-consensus-voting) process.
 
-- Procedural and other issues
-  - Other committer votes not otherwise identified will be voted on in the boinc_dev mailing list
-  - Other PMC votes not otherwise identified will be voted on in the boinc_adm or private boinc_pmc mailing lists as deemed appropriate by the PMC.
+Votes on general availability of a stable release shall use the [consensus voting](#511-consensus-voting) process.
 
-Votes on design reviews, pull requests, and general availability of a stable release shall use the consensus voting process.
-
-Procedural and other issues shall always follow the majority voting process.
+Procedural and other issues (for example, the client release process) shall use the [majority voting](#512-majority-voting) process.
 
 
 ### 5.3 PMC decisions

--- a/Governance.md
+++ b/Governance.md
@@ -253,7 +253,7 @@ The different types of committer decisions should be recorded and discussed in t
 The different types of committer decisions will use the following voting rules:
 - Votes on reported bugs, feature requests, proposed designs, and pull requests shall use the [optimistic consensus voting](#5111-optimistic-consensus-voting) process.
 - Votes on general availability of a stable release shall use the [consensus voting](#511-consensus-voting) process.
-- Procedural and other issues (for example, the client release process) shall use the [majority voting](#512-majority-voting) process.
+- All other committer decisions shall use the [majority voting](#512-majority-voting) process.
 
 
 ### 5.3 PMC decisions

--- a/Governance.md
+++ b/Governance.md
@@ -235,6 +235,9 @@ Majority voting has two phases.  The first is a 14 day discussion period that st
 #### 5.1.3. Super-Majority Voting
 Super-Majority voting has two phases.  The first is a 14 day discussion period that starts when a vote is announced.  Once the 14 day discussion period is concluded, then a 7 day voting period begins.  Super-Majority voting requires that at least 75% of eligible voters cast a vote and, of those who cast a vote, a majority must approve the item.  If this is not obtained by the end of the 7 day voting period, then the vote will have failed.
 
+#### 5.1.4 Reduced discussion and voting periods
+The PMC may vote to reduce discussion and voting periods on a specific vote if at least 75% of the PMC agrees to the reduced periods for that vote.
+
 ### 5.2 Committer decisions
 Committers can vote on issues surrounding the technical infrastructure of the project and the code base itself. This includes voting to determine if a reported bug, feature request, proposed design, or pull request should be accepted. Committers are encouraged to review and participate in the discussion of any of these items, but they are also expected to know when it is advisable to get help from other committers who are stronger in the technology involved or have more experience in the area of application under consideration. Committers are expected to understand the Development Workflow and Client Release Process and their associated guidelines before voting to approve.
 

--- a/Governance.md
+++ b/Governance.md
@@ -169,7 +169,7 @@ Any member of the PMC can call for an election of the PMC Chair.  When a member 
 Elections shall use the election decision process outlined in [section 5.3.2 Election decisions](#532-election-decisions) below.
 
 #### 2.5.3 Inactive Removal
-PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without actively participate in the (processes of the PMC)[#25-project-management-committee] for removal from the PMC.  Removal requires a successful vote using [super majority voting](#531-pmc-decisions-that-require-super-majority-voting) below.
+PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without actively participating in the [processes of the PMC](#25-project-management-committee) should be considered for removal from the PMC.  Removal requires a successful vote using [super majority voting](#531-pmc-decisions-that-require-super-majority-voting) below.
 
 ### 2.6 Official Record
 The official list of committers, supporters and members of the PMC shall be maintained by the secretary at http://boinc.berkeley.edu/trac/wiki/ProjectGovernance. This page shall also clearly list the email address of the PMC public email list with instructions on how someone can subscribe to the list.

--- a/Governance.md
+++ b/Governance.md
@@ -2,7 +2,7 @@
 September 12, 2017
 
 ## 1. Overview
-BOINC is an open-source middleware system for volunteer computing, originally developed at UC Berkeley.  BOINC is a meritocratic, consensus-based project.  Anyone can join the BOINC community and contribute to the project in various ways. Those who consistently make positive contributions, as recognized by other contributors and users, can then become part of the decision-making process.  This document describes the structures and processes governing these activities.
+BOINC is an open-source middleware system for volunteer computing, originally developed at UC Berkeley. BOINC is a meritocratic, consensus-based project. Anyone can join the BOINC community and contribute to the project in various ways. Those who consistently make positive contributions, as recognized by other contributors and users, can then become part of the decision-making process. This document describes the structures and processes governing these activities.
 
 ### 1.1 Mission
 The general goal of the project is to maintain and develop BOINC in a way that:
@@ -18,38 +18,35 @@ Specific goals include:
 - Ensure that future development of BOINC proceeds coherently according to architectural plans agreed upon by the community.
 
 ## 2. Roles and responsibilities
-In the following discussion, it is important to note that people may belong to one or more categories.  For example, someone can be a committer and a PMC member.  In another case, someone might only be a PMC member.  In all cases, one person only gets one vote on issues even if they have multiple roles.
+In the following discussion, it is important to note that people may belong to one or more categories. For example, someone can be a committer and a PMC member. In another case, someone might only be a PMC member. In all cases, one person only gets one vote on issues even if they have multiple roles.
 
 ### 2.1 Users
-“Users” are people who use BOINC in some way.  Examples include:
-
+“Users” are people who use BOINC in some way. Examples include:
 - “Volunteers” run the BOINC client software, contributing processing power and storage capacity to computing projects.
-- “Project admins” operate BOINC-based computing projects (academic science projects, hobbyist projects, commercial projects).  They run the project’s servers, maintain its web site, and develop and deploy its applications.
-- “Add-on developers” create and operate systems that, although not part of BOINC, interact with it through its various APIs.  Examples include: Account managers (such as BAM! And GridRepublic) Statistics web sites (such as BoincStats and BOINC All-Project Stats) GUIs such as BOINCTasks Branded versions of BOINC (such as HTC Power to Give, Samsung Power Sleep, and Intel Progress Thru Processors)
+- “Project admins” operate BOINC-based computing projects (academic science projects, hobbyist projects, commercial projects). They run the project’s servers, maintain its web site, and develop and deploy its applications.
+- “Add-on developers” create and operate systems that, although not part of BOINC, interact with it through its various APIs. Examples include: Account managers (such as BAM! And GridRepublic) Statistics web sites (such as BoincStats and BOINC All-Project Stats) GUIs such as BOINCTasks Branded versions of BOINC (such as HTC Power to Give, Samsung Power Sleep, and Intel Progress Thru Processors)
 - Leaders of BOINC teams.
 
-Anyone can be a user.  The project asks its users to participate in the project and community as much as possible, for example by:
-
+Anyone can be a user. The project asks its users to participate in the project and community as much as possible, for example by:
 - Evangelizing about the project (e.g. by web links or word of mouth)
 - Informing the community of strengths and weaknesses of BOINC’s products
 - Users may contribute in other ways, as described below.
 
 ### 2.2 Contributors
 “Contributors” are people who contribute in concrete ways to BOINC, other than by computing for a BOINC-based project. Forms of contribution include:
-
 - Programming
 - Testing and bug reporting
 - Writing and editing documentation
 - Doing translations for a particular language
 - Identifying and defining new software requirements
-- Providing “customer support” by answering questions from  volunteers and contributors
+- Providing “customer support” by answering questions from volunteers and contributors
 - Providing infrastructure (servers, hosting of email lists)
 - Financial support, such as paying the salary of other contributors
 
-In some forms of contribution, such as programming and documentation, contributors submit changes by developing code in branches and submitting them as pull requests for review by committers (see the next section).  As contributors gain experience, their reputation within the community will increase.  Contributors can nominate themselves or other people to the PMC as potential committers.
+In some forms of contribution, such as programming and documentation, contributors submit changes by developing code in branches and submitting them as pull requests for review by committers (see the next section). As contributors gain experience, their reputation within the community will increase. Contributors can nominate themselves or other people to the PMC as potential committers. 
 
 ### 2.3 Committers
-“Committers” are contributors who have shown, via a sequence of positive contributions, their value to the project.  Committers facilitate the software development process both by contributing code themselves and also by mentoring contributors to help them become more effective contributors.  Only committers can merge a pull request into the master branch and they should only do so through the process defined in Section 4.  Committers have voting rights in the consensus process as it pertains to proposed design changes and to the reviews of pull requests. They contribute to discussion and approval of the software development process as documented in Section 4.
+“Committers” are contributors who have shown, via a sequence of positive contributions, their value to the project. Committers facilitate the software development process both by contributing code themselves and also by mentoring contributors to help them become more effective contributors. Only committers can merge a pull request into the master branch and they should only do so through the process defined in Section 4. Committers have voting rights in the consensus process as it pertains to proposed design changes and to the reviews of pull requests. They contribute to discussion and approval of the software development process as documented in Section 4.
 
 Each committer will be associated with one or more “areas” of the project:
 
@@ -166,7 +163,7 @@ There are a few types of items that require a vote:
 
 Votes on design reviews, pull requests, and general availability of a stable release shall use the consensus voting process.
 
-  Procedural and other issues shall always follow the majority voting process.
+Procedural and other issues shall always follow the majority voting process.
 
 ### 5.1.1 Consensus Voting
 Consensus voting consists of a 7 day review period. During this time anyone can review and discuss the item. At the end of the 7 day period, if there is at least one "Yes" vote for an item (apart from the vote of the person who created the item) and zero "No" votes, then the vote shall be deemed as having passed.

--- a/Governance.md
+++ b/Governance.md
@@ -133,15 +133,15 @@ The “PMC Chair” is a member of the PMC, elected by the PMC to take this role
 - Ensures that votes are taken promptly on issues that require votes
 - Schedules monthly meetings of the PMC
 
-The PMC Chair shall be elected for a term of one year.  They can be re-elected to successive terms.
+The PMC Chair shall be elected for a term of one year.  They can be re-elected to successive terms up to a maximum of three consecutive terms.
 
 ##### 2.5.1.2 PMC Secretary
-The "PMC Secretary" is a member of the PMC, elected by the PMC to take this role.  The secretary has the following responsibilities:
+The "PMC Secretary" is a member of the PMC, appointed and ratified by the PMC to take this role.  The secretary has the following responsibilities:
 - Ensure that items posted in the public PMC mailing list are addressed   
 - Take notes at monthly meetings of the PMC and distribute them to all PMC members within 7 days of the meeting
   - Must officially record who attends each meeting as part of the minutes
 - Ensure that a public version of the notes is distributed on the public PMC mailing list
-- Determine if PMC members need to be removed due to inactivity
+- Monitor and identify PMC members who should be considered for removal due to inactivity (see [2.5.3 Inactive Removal](#253-inactive-removal) below)
 - Maintain the official record of committers, supporters and members of the PMC (see [section 2.6 Official Record](#26-official-record) below)
 - Act as the official vote counter and recorder for all votes taken
   - An email to the private PMC list must made at the conclusion of each vote stating:
@@ -152,21 +152,17 @@ The "PMC Secretary" is a member of the PMC, elected by the PMC to take this role
     - What was the issue voted on
     - The outcome of the vote
     - Who voted
-  - In the event that the PMC determines a vote is sensitive in nature, then they can vote to not announce the vote publically.  The PMC is encouraged to do this rarely and with clear justification.
+  - In the event that the PMC determines a vote is sensitive in nature, then they can decide to not announce the vote publicly.  The PMC is encouraged to do this rarely and with clear justification.
 
-The PMC Secretary shall be elected for a term of one year.   They can be re-elected to successive terms. 
+The PMC Secretary is appointed by the Chair and ratified by the PMC to serve in this role.  Another person can be appointed to this position as determined by the PMC Chair.
 
 #### 2.5.2 PMC Elections
-Any member of the PMC can call for an election of the PMC Chair or Secretary.  When a member of the PMC calls for an election they must specify that the election is either to immediately replace the current Chair or Secretary or if the newly elected Chair or Secretary will start their term when the current term expires. 
+Any member of the PMC can call for an election of the PMC Chair.  When a member of the PMC calls for an election they must specify that the election is either to immediately replace the current Chair or if the newly elected Chair will start their term when the current term expires. 
 
 Elections shall use the election decision process outlined in [section 5.3.2 Election decisions](#532-election-decisions) below.
 
 #### 2.5.3 Inactive Removal
-PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without participating in at least one PMC meeting will be subject to removal from the PMC. 
-
-Periodically, the PMC secretary will review who has participated in meetings and will determine if any PMC members have become inactive and call for a vote of their removal from the PMC.  Whenever this occurs the public listing of PMC members should be updated and the removal should be communicated to the former PMC member as well as shared on the private PMC mailing list.
-
-The rules for removal shall take effect after July 1st, 2018.
+PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without participating in at least one PMC meeting should be considered for removal from the PMC. 
 
 ### 2.6 Official Record
 The official list of committers, supporters and members of the PMC shall be maintained by the secretary at http://boinc.berkeley.edu/trac/wiki/ProjectGovernance. This page shall also clearly list the email address of the PMC public email list with instructions on how someone can subscribe to the list.
@@ -218,14 +214,14 @@ There are a few types of items that require a vote:
 - A change in code or configuration to the system (documented and voted on as a pull request on github)
 - General availability of stable releases (documented and voted on in the boinc_alpha mailing list)
 - Procedural and other issues
-  - Other committer votes not otherwise identified above will be voted on in the boinc_dev mailing list
-  - Other PMC votes not otherwise identified above will be voted on in the boinc_adm or private boinc_pmc mailing lists as deemed appropriate by the PMC Chair.
+  - Other committer votes not otherwise identified will be voted on in the boinc_dev mailing list
+  - Other PMC votes not otherwise identified will be voted on in the boinc_adm or private boinc_pmc mailing lists as deemed appropriate by the PMC.
 
 Votes on design reviews, pull requests, and general availability of a stable release shall use the consensus voting process.
 
 Procedural and other issues shall always follow the majority voting process.
 
-### 5.1.1 Consensus Voting
+#### 5.1.1 Consensus Voting
 Consensus voting consists of a 7 day review period. During this time anyone can review and discuss the item. At the end of the 7 day period, if there is at least one "Yes" vote for an item (apart from the vote of the person who created the item) and zero "No" votes, then the vote shall be deemed as having passed.
 
 A vote of "No" shall not be valid unless it is accompanied by a detailed explanation of the objection to the item. It is preferable to suggest an alternative implementation if possible.
@@ -253,14 +249,15 @@ Decisions of the following types must be made by a special vote of the PMC:
 - Changes to the project governance structure (i.e. changes to this document)
 
 Votes can be called by any PMC member. The special voting process is:
-- A vote is announced on the PMC public list, phrasing the issue as a yes/no decision
-- Discussion of the issue (by the entire community) takes place on the PMC public list. Sensitive discussion among PMC members uses the PMC private list
-- PMC members cast their votes publicly (by email on the PMC public list)
-- Votes on these issues are decided by agreement of at least 75% of responding voters. The vote will be final when there is agreement of at least 75% of PMC members, or when 14 days have passed since the vote was called.
-- If there is not agreement of at least 75% of responding voters, no action is taken on the issue
+- A vote is announced on either the PMC public or private email list (depending on the sensitivity of topic), phrasing the issue as a yes/no decision.
+- If the vote is announced on the PMC public list, then the entire community is encouraged to participate in the discussion of the vote and that discussion should occur on the PMC public list. 
+- If the vote is accouned on the PMC private list, then discussion is limited to PMC members and it shall be conducted in a meeting or on the PMC private email list.
+- Vote outcomes are announced by the PMC secretary as described in [section 2.5.1.2 PMC Secretary](#2512-pmc-secretary)
+- Votes on these issues requires that at least 75% of eligible voters cast a vote and, of those who cast a vote, a majority must approve the item.
+- If there is not agreement of a majority of at least 75% of eligible voters, no action is taken on the issue.
 
 #### 5.3.2 Election decisions
-The PMC will conduct elections to elect the PMC Chair and PMC Secretary.   An election starts when any member of the PMC calls for an election as specified in section 2.5.2 PMC Elections.  This call starts a 7 day nomination period which is followed by a 7 day voting period.  Any member of the PMC can nominate themselves or another member of the PMC to be the PMC Chair or PMC Secretary.  A nomination is only valid if the person nominated accepts the nomination.  Once the 7 day nomination period ends, the 7 day voting period begins automatically.  At the conclusion of 7 day voting period and if at least 75% of the membership of the PMC has voted, then the person with the majority of votes is elected. 
+The PMC will conduct elections to elect the PMC Chair.   An election starts when any member of the PMC calls for an election as specified in section 2.5.2 PMC Elections.  This call starts a 7 day nomination period which is followed by a 7 day voting period.  Any member of the PMC can nominate themselves or another member of the PMC to be the PMC Chair.  A nomination is only valid if the person nominated accepts the nomination.  Once the 7 day nomination period ends, the 7 day voting period begins automatically.  At the conclusion of 7 day voting period and if at least 75% of the membership of the PMC has voted, then the person with the majority of votes is elected. 
 
 All nominations and voting need to be recorded on the private PMC mailing list.
 
@@ -268,7 +265,7 @@ All nominations and voting need to be recorded on the private PMC mailing list.
 Various situations can arise during voting.  Some of these are listed below with the actions that should be taken if they occur:
 - If fewer than 75% of the members of the PMC cast a vote during the 7 day voting period, then a new election must be held.
 - In the event that no-one has a majority at the end of the 7 day voting period, then a new election must be held.
-- If after 2 attempts to conduct an election no-one has been elected or nominated, then the previous chair or secretary is automatically re-instated to a new one year term.
+- If after 2 attempts to conduct an election no-one has been elected or nominated, then the previous chair is automatically re-instated to a new one year term.
 - In the event that a member of the PMC reports an issue with regards to access to the PMC private mailling list that impacts their ability to nominate someone or cast a vote, then the election shall be null and void and must be redone once the issue is resolved.
 
 #### 5.3.3 Other voting decisions

--- a/Governance.md
+++ b/Governance.md
@@ -169,7 +169,7 @@ Any member of the PMC can call for an election of the PMC Chair.  When a member 
 Elections shall use the election decision process outlined in [section 5.3.2 Election decisions](#532-election-decisions) below.
 
 #### 2.5.3 Inactive Removal
-PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without participating in at least one PMC meeting should be considered for removal from the PMC.  Removal requires a successful vote using the process outlined in [special voting procedures](#531decisions-where-special-voting-procedures-are-mandatory) below.
+PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without participating in at least one PMC meeting should be considered for removal from the PMC.  Removal requires a successful vote using [super majority voting](#531-pmc-decisions-that-require-super-majority-voting) below.
 
 ### 2.6 Official Record
 The official list of committers, supporters and members of the PMC shall be maintained by the secretary at http://boinc.berkeley.edu/trac/wiki/ProjectGovernance. This page shall also clearly list the email address of the PMC public email list with instructions on how someone can subscribe to the list.
@@ -255,7 +255,7 @@ Procedural and other issues shall always follow the majority voting process.
 ### 5.3 PMC decisions
 PMC decisions will be made by majority voting unless specified in section 5.3.1 or in section 5.3.2.
 
-Votes can be called by any PMC member. The special voting process is:
+Votes can be called by any PMC member. The process is:
 - A vote is announced on either the PMC public or private email list (depending on the sensitivity of topic), phrasing the issue as a yes/no decision.
 - If the vote is announced on the PMC public list, then the entire community is encouraged to participate in the discussion of the vote and that discussion should occur on the PMC public list. 
 - If the vote is accouned on the PMC private list, then discussion is limited to PMC members and it shall be conducted in a meeting or on the PMC private email list.

--- a/Governance.md
+++ b/Governance.md
@@ -169,7 +169,7 @@ Any member of the PMC can call for an election of the PMC Chair.  When a member 
 Elections shall use the election decision process outlined in [section 5.3.2 Election decisions](#532-election-decisions) below.
 
 #### 2.5.3 Inactive Removal
-PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without participating in at least one PMC meeting should be considered for removal from the PMC.  Removal requires a successful vote using [super majority voting](#531-pmc-decisions-that-require-super-majority-voting) below.
+PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without actively participate in the (processes of the PMC)[#25-project-management-committee] for removal from the PMC.  Removal requires a successful vote using [super majority voting](#531-pmc-decisions-that-require-super-majority-voting) below.
 
 ### 2.6 Official Record
 The official list of committers, supporters and members of the PMC shall be maintained by the secretary at http://boinc.berkeley.edu/trac/wiki/ProjectGovernance. This page shall also clearly list the email address of the PMC public email list with instructions on how someone can subscribe to the list.

--- a/Governance.md
+++ b/Governance.md
@@ -40,7 +40,7 @@ Anyone can be a user. The project asks its users to participate in the project a
 - Doing translations for a particular language
 - Identifying and defining new software requirements
 - Providing “customer support” by answering questions from volunteers and contributors
-- Providing infrastructure (servers, hosting of email lists)
+- Providing infrastructure (servers for distributing/testing BOINC, hosting of BOINC email lists)
 - Financial support, such as paying the salary of other contributors
 
 In some forms of contribution, such as programming and documentation, contributors submit changes by developing code in branches and submitting them as pull requests for review by committers (see the next section). As contributors gain experience, their reputation within the community will increase. Contributors can nominate themselves or other people to the PMC as potential committers. 
@@ -107,22 +107,22 @@ Supporters can resign by sending an email to the PMC chair or the PMC public ema
 
 ### 2.5 Project Management Committee
 The Project Management Committee (PMC) is a group of community members who engage with and play a leadership role on the BOINC project.  They are selected on the basis of one or more of the following criteria:
-- Directly contributing in any of the ways listed in [section 2.2 Contributors](#22-contributors)
+- Directly contributing in any of the ways listed in [section 2.2 Contributors](#22-contributors), [section 2.3 Committers](#23-committers) or [section 2.4 Supporters](#24-supporters)
 - Operating a related system, such as an account manager, that is used by a significant number of volunteers
 - Operating a project with a significant number of volunteers
 - Contributing significant resources to the BOINC project, for example by paying the salary of a contributor
 - Thought leaders in the field of high performance computing who have an interest in promoting the use of volunteer computing
 
 The functions of the PMC are:
-- Decide on the strategic directions of the project
-- Decide issues of intellectual property (copyright, licensing) and other legal issues
+- Set the priorities and the strategic directions of the project
+- Decide issues of intellectual property (copyright, licensing) and other legal matters
 - Support and encourage the recruitment and development of committers and supporters
 - Ensure that necessary tasks for the long term success of the BOINC project are being done
 - Resolve conflicts within the community
 - Review and vote on nominated committers and supporters
 - Vote on adding or removing members of the PMC as needed
 - Decide on the set of “approved” projects and account managers             
-- Modify the governance policies of the BOINC project as needed
+- Update the governance policies of the BOINC project as needed
 - And any other such other thing as might be required from time to time     
 
 Individual PMC members are expected to actively participate in these processes by:
@@ -268,7 +268,7 @@ Votes can be called by any PMC member. The process is:
 #### 5.3.1 PMC Decisions that Require Super-Majority Voting 
 The following types of decisions require a super-majority vote of the PMC
 - Intellectual property issues, e.g. those involving copyright and licensing of BOINC code
-- Other legal and financial decisions
+- Other legal and financial matters
 - PMC membership changes
 - Changes to the project governance structure (i.e. changes to this document)
 

--- a/Governance.md
+++ b/Governance.md
@@ -230,10 +230,10 @@ Issues and pull requests, which are easily reversible, will follow a slightly mo
 With optimistic consensus, once a yes vote has been recorded and if there are no "No" votes yet recorded, then work can start on an issue and a pull request can be reviewed and merged.  However, discussion is still open until 7 day review period expires.  If during this time a "No" vote is recorded and cannot be resolved through discussion, then the work should stop on the issue and the pull request merge should be reverted since the vote will be deemed to have failed. 
 
 #### 5.1.2 Majority Voting
-Majority voting requires that at least 66% of eligible voters cast a vote and, of those who cast a vote, a majority must approve the item.
+Majority voting has two phases.  The first is a 14 day discussion period that starts when a vote is announced.  Once the 14 day discussion period is concluded, then a 7 day voting period begins.  Majority voting requires that at least 66% of eligible voters cast a vote and, of those who cast a vote, a majority must approve the item.  If this is not obtained by the end of the 7 day voting period, then the vote will have failed.
 
 #### 5.1.3. Super-Majority Voting
-Super-majority voting requires that at least 75% of eligible voters cast a vote and, of those who cast a vote, a majority must approve the item.
+Super-Majority voting has two phases.  The first is a 14 day discussion period that starts when a vote is announced.  Once the 14 day discussion period is concluded, then a 7 day voting period begins.  Super-Majority voting requires that at least 75% of eligible voters cast a vote and, of those who cast a vote, a majority must approve the item.  If this is not obtained by the end of the 7 day voting period, then the vote will have failed.
 
 ### 5.2 Committer decisions
 Committers can vote on issues surrounding the technical infrastructure of the project and the code base itself. This includes voting to determine if a reported bug, feature request, proposed design, or pull request should be accepted. Committers are encouraged to review and participate in the discussion of any of these items, but they are also expected to know when it is advisable to get help from other committers who are stronger in the technology involved or have more experience in the area of application under consideration. Committers are expected to understand the Development Workflow and Client Release Process and their associated guidelines before voting to approve.

--- a/Governance.md
+++ b/Governance.md
@@ -243,18 +243,17 @@ Committers can vote on issues surrounding the technical infrastructure of the pr
 
 Committers are expected to subscribe to notifications from github in order to be aware of proposals under consideration. Committers should make a reasonable attempt to respond quickly if they are personally asked to review an item. Since most decisions that committers are involved in will use consensus voting, it is important for them to try to remain aware of proposed items.
 
-Different committer decisions should be recorded and discussed in the following locations:
+The different types of committer decisions should be recorded and discussed in the following locations:
 - Whether or not to fix a bug or implement a feature request (documented and voted on as an issue on github)
 - The design of a proposed feature or bug fix (documented and voted on within the relevant issue on github)
 - A change in code or configuration to the system (documented and voted on as a pull request on github)
 - General availability of stable releases (documented and voted on in the boinc_alpha mailing list)
 - All other committer decisions should be discussed and voted on in the boinc_dev mailing list.
 
-Votes on reported bugs, feature requests, proposed designs, and pull requests shall use the [optimistic consensus voting](#5111-optimistic-consensus-voting) process.
-
-Votes on general availability of a stable release shall use the [consensus voting](#511-consensus-voting) process.
-
-Procedural and other issues (for example, the client release process) shall use the [majority voting](#512-majority-voting) process.
+The different types of committer decisions will use the following voting rules:
+- Votes on reported bugs, feature requests, proposed designs, and pull requests shall use the [optimistic consensus voting](#5111-optimistic-consensus-voting) process.
+- Votes on general availability of a stable release shall use the [consensus voting](#511-consensus-voting) process.
+- Procedural and other issues (for example, the client release process) shall use the [majority voting](#512-majority-voting) process.
 
 
 ### 5.3 PMC decisions

--- a/Governance.md
+++ b/Governance.md
@@ -1,5 +1,5 @@
 # BOINC Project Governance
-September 12, 2017
+December 12, 2017
 
 ## 1. Overview
 BOINC is an open-source middleware system for volunteer computing, originally developed at UC Berkeley. BOINC is a meritocratic, consensus-based project. Anyone can join the BOINC community and contribute to the project in various ways. Those who consistently make positive contributions, as recognized by other contributors and users, can then become part of the decision-making process. This document describes the structures and processes governing these activities.

--- a/Governance.md
+++ b/Governance.md
@@ -225,9 +225,9 @@ If discussion cannot remove the concerns that resulted in the "No" vote, then th
 If the vote fails, but the original proposer of the item still believes that the item is worth pursuing, they can appeal to the PMC. The PMC shall consider the appeal at their next regularly scheduled meeting and will use Majority Voting to determine the outcome.
 
 ##### 5.1.1.1 Optimistic Consensus Voting
-Issue and pull requests, which are easily reversible, will follow a slightly modified version of consensus voting that allows for forward progress while discussion remains open.  
+Issues and pull requests, which are easily reversible, will follow a slightly modified version of consensus voting that allows for forward progress while discussion remains open.  
 
-With optimistic consensus, once a yes vote has been recorded and if there are no "No" votes yet recorded, then work can start on an issue and a pull request can be reviewed and merged.  However, discussion is still open on the issue until 7 day review period expires.  If during this time a "No" vote is recorded and cannot be resolved through discussion, then the work should stop on the issue and the pull request merge should be reverted since the vote will be deemed to have failed. 
+With optimistic consensus, once a yes vote has been recorded and if there are no "No" votes yet recorded, then work can start on an issue and a pull request can be reviewed and merged.  However, discussion is still open until 7 day review period expires.  If during this time a "No" vote is recorded and cannot be resolved through discussion, then the work should stop on the issue and the pull request merge should be reverted since the vote will be deemed to have failed. 
 
 #### 5.1.2 Majority Voting
 Majority voting requires that at least 66% of eligible voters cast a vote and, of those who cast a vote, a majority must approve the item.

--- a/Governance.md
+++ b/Governance.md
@@ -224,6 +224,11 @@ If discussion cannot remove the concerns that resulted in the "No" vote, then th
 
 If the vote fails, but the original proposer of the item still believes that the item is worth pursuing, they can appeal to the PMC. The PMC shall consider the appeal at their next regularly scheduled meeting and will use Majority Voting to determine the outcome.
 
+##### 5.1.1.1 Optimistic Consensus Voting
+Issue and pull requests, which are easily reversible, will follow a slightly modified version of consensus voting that allows for forward progress while discussion remains open.  
+
+With optimistic consensus, once a yes vote has been recorded and if there are no "No" votes yet recorded, then work can start on an issue and a pull request can be reviewed and merged.  However, discussion is still open on the issue until 7 day review period expires.  If during this time a "No" vote is recorded and cannot be resolved through discussion, then the work should stop on the issue and the pull request merge should be reverted since the vote will be deemed to have failed. 
+
 #### 5.1.2 Majority Voting
 Majority voting requires that at least 66% of eligible voters cast a vote and, of those who cast a vote, a majority must approve the item.
 

--- a/Governance.md
+++ b/Governance.md
@@ -1,5 +1,5 @@
 # BOINC Project Governance
-January 12, 2018
+February 14, 2018
 
 ## 1. Overview
 BOINC is an open-source middleware system for volunteer computing, originally developed at UC Berkeley. BOINC is a meritocratic, consensus-based project. Anyone can join the BOINC community and contribute to the project in various ways. Those who consistently make positive contributions, as recognized by other contributors and users, can then become part of the decision-making process. This document describes the structures and processes governing these activities.

--- a/Governance.md
+++ b/Governance.md
@@ -1,5 +1,5 @@
 # BOINC Project Governance
-December 12, 2017
+January 12, 2018
 
 ## 1. Overview
 BOINC is an open-source middleware system for volunteer computing, originally developed at UC Berkeley. BOINC is a meritocratic, consensus-based project. Anyone can join the BOINC community and contribute to the project in various ways. Those who consistently make positive contributions, as recognized by other contributors and users, can then become part of the decision-making process. This document describes the structures and processes governing these activities.

--- a/Governance.md
+++ b/Governance.md
@@ -46,7 +46,7 @@ Anyone can be a user. The project asks its users to participate in the project a
 In some forms of contribution, such as programming and documentation, contributors submit changes by developing code in branches and submitting them as pull requests for review by committers (see the next section). As contributors gain experience, their reputation within the community will increase. Contributors can nominate themselves or other people to the PMC as potential committers. 
 
 ### 2.3 Committers
-“Committers” are contributors who have shown, via a sequence of positive contributions, their value to the project. Committers facilitate the software development process both by contributing code themselves and also by mentoring contributors to help them become more effective contributors. Only committers can merge a pull request into the master branch and they should only do so through the process defined in Section 4. Committers have voting rights in the consensus process as it pertains to proposed design changes and to the reviews of pull requests. They contribute to discussion and approval of the software development process as documented in Section 4.
+“Committers” are contributors who have shown, via a sequence of positive contributions, their value to the project. Committers facilitate the software development process both by contributing code themselves and also by mentoring contributors to help them become more effective contributors. Only committers can merge a pull request into the master branch and they should only do so through the process defined in [4 Contribution Process](#4-contribution-processes). Committers have voting rights in the consensus process as it pertains to proposed design changes and to the reviews of pull requests. They contribute to discussion and approval of the software development process as documented in [4 Contribution Process](#4-contribution-processes).
 
 Each committer will work on one or more “areas” of the BOINC project:
 - Software development and maintenance
@@ -103,7 +103,7 @@ Supporters are expected to do one or more of the following:
 
 ### 2.5 Project Management Committee
 The Project Management Committee (PMC) is a group of community members who engage with and play a leadership role on the BOINC project.  They are selected on the basis of one or more of the following criteria:
-- Directly contributing in any of the ways listed in Section 2.2
+- Directly contributing in any of the ways listed in [Section 2.2 Contributors](#22-contributors)
 - Operating a related system, such as an account manager, that is used by a significant number of volunteers
 - Operating a project with a significant number of volunteers
 - Contributing significant resources to the BOINC project, for example by paying the salary of a contributor
@@ -122,8 +122,8 @@ The functions of the PMC are:
 - And any other such other thing as might be required from time to time     
 
 Individual PMC members are expected to actively participate in these processes by:
-- Reading the PMC public and private email lists (see below)
-- Participating in votes (see below)
+- Reading the PMC public and private email lists (See [3 Communication channels](#3-communication-channels) below)
+- Participating in votes (See [5.3 PMC decisions](#53-pmc-decisions) below)
 
 #### 2.5.1 PMC Positions
 ##### 2.5.1.1 PMC Chair
@@ -142,7 +142,7 @@ The "PMC Secretary" is a member of the PMC, elected by the PMC to take this role
   - Must officially record who attends each meeting as part of the minutes
 - Ensure that a public version of the notes is distributed on the public PMC mailing list
 - Determine if PMC members need to be removed due to inactivity
-- Maintain the official record of committers, supporters and members of the PMC (see section 2.6)
+- Maintain the official record of committers, supporters and members of the PMC (See [2.6 Official Record](#26-official-record) below)
 - Act as the official vote counter and recorder for all votes taken
   - An email to the private PMC list must made at the conclusion of each vote stating:
     - What was the issue voted on
@@ -159,7 +159,7 @@ The PMC Secretary shall be elected for a term of one year.   They can be re-elec
 #### 2.5.2 PMC Elections
 Any member of the PMC can call for an election of the PMC Chair or Secretary.  When a member of the PMC calls for an election they must specify that the election is either to immediately replace the current Chair or Secretary or if the newly elected Chair or Secretary will start their term when the current term expires. 
 
-Elections shall use the election decision process outlined in section 5.3.2 below.
+Elections shall use the election decision process outlined in [5.3.2 Election decisions](#532-election-decisions) below.
 
 #### 2.5.3 Inactive Removal
 PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without participating in at least one PMC meeting will be subject to removal from the PMC. 

--- a/Governance.md
+++ b/Governance.md
@@ -48,70 +48,131 @@ In some forms of contribution, such as programming and documentation, contributo
 ### 2.3 Committers
 “Committers” are contributors who have shown, via a sequence of positive contributions, their value to the project. Committers facilitate the software development process both by contributing code themselves and also by mentoring contributors to help them become more effective contributors. Only committers can merge a pull request into the master branch and they should only do so through the process defined in Section 4. Committers have voting rights in the consensus process as it pertains to proposed design changes and to the reviews of pull requests. They contribute to discussion and approval of the software development process as documented in Section 4.
 
-Each committer will be associated with one or more “areas” of the project:
-
+Each committer will work on one or more “areas” of the BOINC project:
 - Software development and maintenance
 - Translation system
 - Testing and release management
 - Documentation
 - BOINC web site, including News items
 - Support
-- Infrastructure (e.g. setting up and maintaining email lists and Github repository; maintaining BOINC web server)
+- Infrastructure (e.g. setting up and maintaining email lists and Github repository; maintaining BOINC web server)     
+- And any other such thing as might be required from time to time
 
-Depending on the committer’s area(s), they will be given specific privileges such as:
-
+Depending on the committers' area(s), they can be given one or more specific privileges such as:
 - Commit access to the source code repository
 - Write access to the documentation Wikis
 - Write access to the public web site
-- Moderator status on project message boards
+- Moderator status on the BOINC project message boards
 
-Committers are expected to:
-
+Committers are expected to do several of the following:
 - Read the communication channels relevant to their area(s)
 - Subscribe to pull request notifications within github (https://help.github.com/categories/notifications/)
 - Review bug reports and features and make sure that they are valid and contain sufficient detail to implement
 - Review proposed solutions to bugs and feature requests
 - Prioritize bug reports and features so that contributors and other developers know which issues are most important and in need of contribution
 - Review pull requests and merge code when appropriate
-- Identify contributors who would be helpful as committers; nominate these contributors to the PMC via the PMC email distribution list for consideration
+- Identify contributors who would be helpful as committers; nominate these contributors to the PMC
 
-### 2.4 Project Management Committee
-The Project Management Committee (PMC) is a group of community members who have consistently and significantly contributed to the project, for example by
+### 2.4 Supporters
+"Supporters" are contributors who have shown, via continued contribution over a period of time, their value to the project.  Supporters are focused on the end user experience and support the project by engaging with end-users wherever they may engage with the BOINC software and BOINC projects to both help the end-users as well as open issues as needed when there is a need for a change in the software.  Supporters also contribute by performing functions such as testing, enhancing documentation, and creating translations.
 
+"Supporters" are similar to "Committers" except that they are not contributing source code to the project.  They have voting rights equal to committers except that they cannot vote on issues that specifically pertain to software architecture and source code.
+
+Each supporter will work on one or more “areas” of the BOINC project:
+- Translation system
+- Testing and release management
+- Documentation
+- BOINC web site, including News items
+- Support
+- And any other such other thing as might be required from time to time     
+
+Depending on the supporter’s area(s), they can be given one or more specific privileges such as:
+- Permission to manage issues on GitHub
+- Write access to the documentation Wikis
+- Write access to the public web site
+- Moderator status on the BOINC project message boards
+
+Supporters are expected to do one or more of the following:
+- Periodically review a few of the BOINC, project and team forums in order to remain aware of the experience the end-users are reporting with the software
+- Identify bugs, issues and feature requests from users and turn them into issues on GitHub
+- Review bug reports and features and make sure that they are valid and contain sufficient detail to implement
+- Prioritize bug reports and features so that contributors and other developers know which issues are most important and in need of contribution
+- Read the communication channels relevant to their area(s)
+- Assist with testing new releases of the software
+- Identify contributors who would be helpful as supporters; nominate these contributors to the PMC
+
+### 2.5 Project Management Committee
+The Project Management Committee (PMC) is a group of community members who engage with and play a leadership role on the BOINC project.  They are selected on the basis of one or more of the following criteria:
 - Directly contributing in any of the ways listed in Section 2.2
 - Operating a related system, such as an account manager, that is used by a significant number of volunteers
-- Operating a BOINC project with a significant number of volunteers
-- Contributing significant resources to the project, for example by paying the salary of a contributor
+- Operating a project with a significant number of volunteers
+- Contributing significant resources to the BOINC project, for example by paying the salary of a contributor
+- Thought leaders in the field of high performance computing who have an interest in promoting the use of volunteer computing
 
 The functions of the PMC are:
-
 - Decide on the strategic directions of the project
 - Decide issues of intellectual property (copyright, licensing) and other legal issues
-- Review and vote on nominated committers
-- Decide on PMC membership
-- Decide on the set of “approved” projects and account managers
-- Modify the governance policies of the project as needed
+- Support and encourage the recruitment and development of committers and supporters
+- Ensure that necessary tasks for the long term success of the BOINC project are being done
+- Resolve conflicts within the community
+- Review and vote on nominated committers and supporters
+- Vote on adding or removing members of the PMC as needed
+- Decide on the set of “approved” projects and account managers             
+- Modify the governance policies of the BOINC project as needed
+- And any other such other thing as might be required from time to time     
 
-PMC members are expected to actively participate in these processes, by
-
-- Reading the PMC email lists (see below)
+Individual PMC members are expected to actively participate in these processes by:
+- Reading the PMC public and private email lists (see below)
 - Participating in votes (see below)
 
-#### 2.4.1 PMC Chair
+#### 2.5.1 PMC Positions
+##### 2.5.1.1 PMC Chair
 The “PMC Chair” is a member of the PMC, elected by the PMC to take this role. The chair has the following responsibilities:
+- Ensures that the functions of the PMC are being performed   
+- Ensures that the activities of the BOINC community are in agreement with this document and established procedures
+- Ensures that votes are taken promptly on issues that require votes
+- Schedules monthly meetings of the PMC
 
-- Ensure that votes are taken on issues that require votes
-- Ensure that the activities of the BOINC community are in agreement with this document and established procedures
-- Schedule monthly meetings of the PMC
+The PMC Chair shall be elected for a term of one year.  They can be re-elected to successive terms.
 
-The Chair remains in that role until they retire or the PMC votes to remove them. He or she has no additional authority beyond that of other PMC members.
+##### 2.5.1.2 PMC Secretary
+The "PMC Secretary" is a member of the PMC, elected by the PMC to take this role.  The secretary has the following responsibilities:
+- Ensure that items posted in the public PMC mailing list are addressed   
+- Take notes at monthly meetings of the PMC and distribute them to all PMC members within 7 days of the meeting
+  - Must officially record who attends each meeting as part of the minutes
+- Ensure that a public version of the notes is distributed on the public PMC mailing list
+- Determine if PMC members need to be removed due to inactivity
+- Maintain the official record of committers, supporters and members of the PMC (see section 2.6)
+- Act as the official vote counter and recorder for all votes taken
+  - An email to the private PMC list must made at the conclusion of each vote stating:
+    - What was the issue voted on
+    - The outcome of the vote
+    - Who voted and how they cast their vote
+  - An email sent to the public PMC list must be made at the conclusion of each vote stating:
+    - What was the issue voted on
+    - The outcome of the vote
+    - Who voted
+  - In the event that the PMC determines a vote is sensitive in nature, then they can vote to not announce the vote publically.  The PMC is encouraged to do this rarely and with clear justification.
 
-### 2.5 Official Record
-The official list of committers and members of the PMC shall be maintained at http://boinc.berkeley.edu/trac/wiki/ProjectGovernance. This page shall also clearly list the email address of the PMC public email list with instructions on how someone can subscribe to the list.
+The PMC Secretary shall be elected for a term of one year.   They can be re-elected to successive terms. 
+
+#### 2.5.2 PMC Elections
+Any member of the PMC can call for an election of the PMC Chair or Secretary.  When a member of the PMC calls for an election they must specify that the election is either to immediately replace the current Chair or Secretary or if the newly elected Chair or Secretary will start their term when the current term expires. 
+
+Elections shall use the election decision process outlined in section 5.3.2 below.
+
+#### 2.5.3 Inactive Removal
+PMC members are expected to remain engaged and connected to the community.  If they are not, then they cannot effectively act as the advisor and leader to the community as is their role.  As a result, any member of the PMC that goes for a year without participating in at least one PMC meeting will be subject to removal from the PMC. 
+
+Periodically, the PMC secretary will review who has participated in meetings and will determine if any PMC members have become inactive and call for a vote of their removal from the PMC.  Whenever this occurs the public listing of PMC members should be updated and the removal should be communicated to the former PMC member as well as shared on the private PMC mailing list.
+
+The rules for removal shall take effect after July 1st, 2018.
+
+### 2.6 Official Record
+The official list of committers, supporters and members of the PMC shall be maintained by the secretary at http://boinc.berkeley.edu/trac/wiki/ProjectGovernance. This page shall also clearly list the email address of the PMC public email list with instructions on how someone can subscribe to the list.
 
 ## 3. Communication channels
 The project will provide communication channels for various purposes:
-
 - PMC public email list, used for:
   - Requests to be a submitter
   - Requests to be a PMC member
@@ -143,16 +204,15 @@ The process of making technical or code contributions is the same for everyone, 
   - Review the Project (https://github.com/BOINC/boinc/projects) associated with the area of BOINC in which you want to contribute
   - Issues that have been reviewed and are ready for implementation are listed under Longterm or TODO
   - Issues with a higher priority for implementation are listed under TODO
-- Follow the software development process that BOINC uses (See [Development_Workflow.md](../../blob/master/Development_Workflow.md))
+- Follow the software development process that BOINC uses (See [Development_Workflow.md](Development_Workflow.md))
 
-If you are reporting a bug or requesting a feature, make sure you review the [Development Workflow](../../blob/master/Development_Workflow.md) before you submit it.
+If you are reporting a bug or requesting a feature, make sure you review the [Development Workflow](Development_Workflow.md) before you submit it.
 
 ## 5. Decision processes
 ### 5.1 Voting Processes
 Because one of the fundamental aspects of accomplishing things within the BOINC framework is doing so by consensus, it is necessary to determine whether consensus has been reached. This is done by voting.
 
 There are a few types of items that require a vote:
-
 - Whether or not to fix a bug or implement a feature request (documented and voted on as an issue on github)
 - The design of a proposed feature or bug fix (documented and voted on within the relevant issue on github)
 - A change in code or configuration to the system (documented and voted on as a pull request on github)
@@ -187,20 +247,29 @@ Certain specific types of decisions by the PMC must be made by a special voting 
 
 #### 5.3.1 Decisions where special voting procedures are mandatory
 Decisions of the following types must be made by a special vote of the PMC:
-
 - Intellectual property issues, e.g. those involving copyright and licensing of BOINC code
 - Other legal and financial decisions
-- PMC membership
-- Selection of the PMC chair
+- PMC membership changes
 - Changes to the project governance structure (i.e. changes to this document)
 
 Votes can be called by any PMC member. The special voting process is:
-
 - A vote is announced on the PMC public list, phrasing the issue as a yes/no decision
 - Discussion of the issue (by the entire community) takes place on the PMC public list. Sensitive discussion among PMC members uses the PMC private list
 - PMC members cast their votes publicly (by email on the PMC public list)
 - Votes on these issues are decided by agreement of at least 75% of responding voters. The vote will be final when there is agreement of at least 75% of PMC members, or when 14 days have passed since the vote was called.
 - If there is not agreement of at least 75% of responding voters, no action is taken on the issue
 
-#### 5.3.2 Other voting decisions
+#### 5.3.2 Election decisions
+The PMC will conduct elections to elect the PMC Chair and PMC Secretary.   An election starts when any member of the PMC calls for an election as specified in section 2.5.2 PMC Elections.  This call starts a 7 day nomination period which is followed by a 7 day voting period.  Any member of the PMC can nominate themselves or another member of the PMC to be the PMC Chair or PMC Secretary.  A nomination is only valid if the person nominated accepts the nomination.  Once the 7 day nomination period ends, the 7 day voting period begins automatically.  At the conclusion of 7 day voting period and if at least 75% of the membership of the PMC has voted, then the person with the majority of votes is elected. 
+
+All nominations and voting need to be recorded on the private PMC mailing list.
+
+##### 5.3.2.1 Voting Irregularities
+Various situations can arise during voting.  Some of these are listed below with the actions that should be taken if they occur:
+- If fewer than 75% of the members of the PMC cast a vote during the 7 day voting period, then a new election must be held.
+- In the event that no-one has a majority at the end of the 7 day voting period, then a new election must be held.
+- If after 2 attempts to conduct an election no-one has been elected or nominated, then the previous chair or secretary is automatically re-instated to a new one year term.
+- In the event that a member of the PMC reports an issue with regards to access to the PMC private mailling list that impacts their ability to nominate someone or cast a vote, then the election shall be null and void and must be redone once the issue is resolved.
+
+#### 5.3.3 Other voting decisions
 For all other types of decisions that require a PMC vote, the PMC will start decision making using the consensus voting with PMC members voting. If consensus voting fails to reach agreement, the chair or the person who called the vote can request that a majority vote occurs to determine the outcome.


### PR DESCRIPTION
The following proposed changes were developed by the working committee and each item was approved by the committee as a recommendation to the PMC for consideration.  The major changes consist of the following:

- Add the supporters role to recognize the special role and responsabilities that non-developers can play in the ongoing support and maintenance of the project
- Create the position of PMC Secretary who is responsible for various tasks related to documenting and publish the activities of the PMC
- Set the PMC Chair and PMC Secretary to have one year terms
- Establish guidelines for conducting elections for PMC Chair and PMC Secretary
- Clarify that people thought leaders from other communities can become part of the PMC if they have a interest in supporting the BOINC project and volunteer computing
- Establish a process for removing inactive PMC members